### PR TITLE
Add limitation for apple messages

### DIFF
--- a/custom-field.yaml
+++ b/custom-field.yaml
@@ -228,7 +228,7 @@ paths:
         > NB: the social media user is created if not found for this social media account.
         
         
-        Limitation: This feature is not supported for Apple Messages.
+        Limitation: This feature is not available yet for Apple Messages. If you are considering using it, please contact our support team at support@alcmeon.com
       requestBody:
         content:
           application/json:
@@ -261,7 +261,7 @@ paths:
         Return user custom fields for a social media user.
         
         
-        Limitation: This feature is not supported for Apple Messages.
+        Limitation: This feature is not available yet for Apple Messages. If you are considering using it, please contact our support team at support@alcmeon.com
       responses:
         '200':
           description: Returned upon succes

--- a/custom-field.yaml
+++ b/custom-field.yaml
@@ -78,18 +78,56 @@ components:
             type: integer
           field_value:
             $ref: '#/components/schemas/PrimitiveFieldValues'
-  
+
     ResponseError:
       type: object
       properties:
         error:
           type: string
-          description: A short string explaining the reason of the error.  
+          description: A short string explaining the reason of the error.
         details:
           type: string
           description: >
             A short string which describes what is wrong. Provide this string to 
             support@alcmeon.com if you wish to obtain more details about the problem.
+
+    FieldMetadata:
+      description: Metadata for custom fields
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Id of the custom field
+        label:
+          type: string
+          description: Label of the custom field
+        description:
+          type: string
+          description: Description of the custom field
+        type:
+          type: string
+        teams:
+          type: array
+          items:
+            type: integer
+        can_set_null:
+          type: boolean
+        allowed:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              label:
+                type: string
+          description: List of allowed values. Only return if the type is 'multipicklist' or 'enum'
+        last_modified_by:
+          type: string
+        last_modified_on:
+          type: string
+          format: date-time
+
 
     ResponseOk:
       type: string
@@ -261,3 +299,42 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FieldValues'
+
+  /custom-field/users/fields/{custom_field_id}:
+    parameters:
+      - in: path
+        name: custom_field_id
+        description: A custom_field_id which uniquely identifies a custom field.
+        required: true
+        schema:
+          type: integer
+    get:
+      tags:
+        - Fields
+      summary: Get metadata for a custom field
+      description: >
+        Return the metadata for the given custom field id
+      responses:
+        '200':
+          description: Returned upon succes
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FieldMetadata'
+
+  /custom-field/users/fields:
+    get:
+      tags:
+        - Fields
+      summary: Get metadata for all custom fields
+      description: >
+        Return the metadata for all user custom fields
+      responses:
+        '200':
+          description: Returned upon succes
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FieldMetadata'

--- a/custom-field.yaml
+++ b/custom-field.yaml
@@ -226,6 +226,9 @@ paths:
         Set user custom fields for a given social media user.
         
         > NB: the social media user is created if not found for this social media account.
+        
+        
+        Limitation: This feature is not supported for Apple Messages.
       requestBody:
         content:
           application/json:
@@ -256,6 +259,9 @@ paths:
       summary: Get fields for a social media user
       description: >
         Return user custom fields for a social media user.
+        
+        
+        Limitation: This feature is not supported for Apple Messages.
       responses:
         '200':
           description: Returned upon succes

--- a/custom-field.yaml
+++ b/custom-field.yaml
@@ -106,12 +106,15 @@ components:
           description: Description of the custom field
         type:
           type: string
+          enum: [integer, float, boolean, enum, multipicklist, string, url, phone, email, datetime, date]
         teams:
           type: array
+          description: id of the teams that can view/edit the custom field. See [/teams](#https://developers.alcmeon.com/reference/get_teams)
           items:
             type: integer
-        can_set_null:
+        optional:
           type: boolean
+          description: If true, this custom field is optional
         allowed:
           type: array
           items:
@@ -122,11 +125,14 @@ components:
               label:
                 type: string
           description: List of allowed values. Only return if the type is 'multipicklist' or 'enum'
-        last_modified_by:
+        last_updater_admin_user_email:
           type: string
+          description: Email address of the last modifier
         last_modified_on:
           type: string
           format: date-time
+          description: Last datetime of edition? ISO format in GMT
+
 
 
     ResponseOk:

--- a/custom-field.yaml
+++ b/custom-field.yaml
@@ -327,7 +327,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FieldMetadata'
-
+        '404':
+          description: Returned if the custom field id is not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
   /custom-field/users/fields:
     get:
       tags:


### PR DESCRIPTION
Apple Messages user id are not supported in our custom field API. The ID needs to be base64 encoded.

For simplicity and coherence with the other IDs, it's easier to not support this feature for Apple Messages for now