### PR TITLE
SP-9207 Add bearer token auth to documented API endpoints, centralize…

### DIFF
--- a/ai-api.yaml
+++ b/ai-api.yaml
@@ -12,12 +12,9 @@ components:
 
   securitySchemes:
     basic_auth:
-      description: >
-        This is the default authentication schema for api.alcmeon.com.
-        The username is your `company_id` (the id of your environment within Alcméon).
-        The password is available from the _Applications_ configuration page within Alcméon.
-      type: http
-      scheme: basic
+      $ref: 'shared-security.yaml#/components/securitySchemes/basic_auth'
+    bearer_token:
+      $ref: 'shared-security.yaml#/components/securitySchemes/bearer_token'
 
   schemas:
     ResponseError:
@@ -331,6 +328,7 @@ components:
           
 security:
   - basic_auth: []
+  - bearer_token: []
 
 paths:
   /ai/answer:

--- a/application.yaml
+++ b/application.yaml
@@ -14,12 +14,9 @@ components:
 
   securitySchemes:
     basic_auth:
-      description: >
-        This is the default authentication schema for api.alcmeon.com.
-        The username is your `company_id` (the id of your environment within Alcméon).
-        The password is available from the _Applications_ configuration page within Alcméon.
-      type: http
-      scheme: basic
+      $ref: 'shared-security.yaml#/components/securitySchemes/basic_auth'
+    bearer_token:
+      $ref: 'shared-security.yaml#/components/securitySchemes/bearer_token'
 
   schemas:
 
@@ -91,6 +88,7 @@ components:
 
 security:
   - basic_auth: []
+  - bearer_token: []
 
 paths:
 

--- a/core-api.yaml
+++ b/core-api.yaml
@@ -13,12 +13,9 @@ x-readme:
 components:
   securitySchemes:
     basic_auth:
-      description: >
-        This is the default authentication schema for api.alcmeon.com.
-        The username is your `company_id` (the id of your environment within Alcméon).
-        The password is available from the _Applications_ configuration page within Alcméon.
-      type: http
-      scheme: basic
+      $ref: 'shared-security.yaml#/components/securitySchemes/basic_auth'
+    bearer_token:
+      $ref: 'shared-security.yaml#/components/securitySchemes/bearer_token'
 
   schemas:
     ResponseError:
@@ -77,6 +74,7 @@ components:
 
 security:
   - basic_auth: []
+  - bearer_token: []
 
 paths:
   /v1/social-accounts/:

--- a/custom-field.yaml
+++ b/custom-field.yaml
@@ -11,16 +11,14 @@ x-readme:
 
 security:
   - basic_auth: []
+  - bearer_token: []
 
 components:
   securitySchemes:
     basic_auth:
-      description: >
-        This is the default authentication schema for api.alcmeon.com.
-        The username is your `company_id` (the id of your environment within Alcméon).
-        The password is available from the _Applications_ configuration page within Alcméon.
-      type: http
-      scheme: basic
+      $ref: 'shared-security.yaml#/components/securitySchemes/basic_auth'
+    bearer_token:
+      $ref: 'shared-security.yaml#/components/securitySchemes/bearer_token'
 
   schemas:
     PrimitiveFieldValues:

--- a/embed.yaml
+++ b/embed.yaml
@@ -14,12 +14,7 @@ components:
 
   securitySchemes:
     basic_auth:
-      description: >
-        This is the default authentication schema for api.alcmeon.com.
-        The username is your `company_id` (the id of your environment within Alcméon).
-        The password is available from the _Applications_ configuration page within Alcméon.
-      type: http
-      scheme: basic
+      $ref: 'shared-security.yaml#/components/securitySchemes/basic_auth'
 
 security:
   - basic_auth: []

--- a/exports.yaml
+++ b/exports.yaml
@@ -12,15 +12,13 @@ x-readme:
 components:
   securitySchemes:
     basic_auth:
-      description: >
-        This is the default authentication schema for api.alcmeon.com.
-        The username is your `company_id` (the id of your environment within Alcméon).
-        The password is available from the _Applications_ configuration page within Alcméon.
-      type: http
-      scheme: basic
+      $ref: 'shared-security.yaml#/components/securitySchemes/basic_auth'
+    bearer_token:
+      $ref: 'shared-security.yaml#/components/securitySchemes/bearer_token'
 
 security:
   - basic_auth: []
+  - bearer_token: []
 
 paths:
   /exports:

--- a/kakaotalk-send-api.yaml
+++ b/kakaotalk-send-api.yaml
@@ -12,12 +12,9 @@ components:
 
   securitySchemes:
     basic_auth:
-      description: >
-        This is the default authentication schema for api.alcmeon.com.
-        The username is your `company_id` (the id of your environment within Alcméon).
-        The password is available from the _Applications_ configuration page within Alcméon.
-      type: http
-      scheme: basic
+      $ref: 'shared-security.yaml#/components/securitySchemes/basic_auth'
+    bearer_token:
+      $ref: 'shared-security.yaml#/components/securitySchemes/bearer_token'
 
   schemas:
     ResponseError:
@@ -143,6 +140,7 @@ components:
 
 security:
   - basic_auth: []
+  - bearer_token: []
 
 paths:
   /v1/kakaotalk/templates:

--- a/oauth.yaml
+++ b/oauth.yaml
@@ -11,10 +11,7 @@ x-readme:
 components:
   securitySchemes:
     basic_auth:
-      type: http
-      scheme: basic
-      description: >
-        Basic authentication using your environment Instance ID as username and Application Secret as password.
+      $ref: 'shared-security.yaml#/components/securitySchemes/basic_auth'
 
   schemas:
     UnsuccessfulResponse:
@@ -72,15 +69,18 @@ components:
 
 security:
   - basic_auth: []
+  - {}
 
 paths:
   /v1/oauth2/token:
     post:
       tags: [Authentication]
-      summary: Get an OAuth2 access token.
+      summary: Get an OAuth2 access token
       description: >
         Obtain a Bearer token using the OAuth2 client credentials flow.
         The token is valid for one hour and can be used for subsequent API calls.
+        
+        Note that this endpoint supports both authenticated (Basic Auth) and unauthenticated calls.
       requestBody:
         content:
           application/json:

--- a/scenarios.yaml
+++ b/scenarios.yaml
@@ -14,16 +14,14 @@ components:
 
   securitySchemes:
     basic_auth:
-      description: >
-        This is the default authentication schema for api.alcmeon.com.
-        The username is your `company_id` (the id of your environment within Alcméon).
-        The password is available from the _Applications_ configuration page within Alcméon.
-      type: http
-      scheme: basic
+      $ref: 'shared-security.yaml#/components/securitySchemes/basic_auth'
+    bearer_token:
+      $ref: 'shared-security.yaml#/components/securitySchemes/bearer_token'
 
 
 security:
   - basic_auth: []
+  - bearer_token: []
 
 paths:
 

--- a/shared-security.yaml
+++ b/shared-security.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  title: Shared Security Components
+  version: '1.0'
+  description: >
+    This file contains shared security scheme definitions that can be referenced 
+    by other OpenAPI specification files in the Alcmeon API documentation.
+
+components:
+  securitySchemes:
+    basic_auth:
+      description: >
+        Basic authentication using your environment Instance ID as username and Application Secret as password.
+      type: http
+      scheme: basic
+    bearer_token:
+      description: >
+        OAuth 2.0 Bearer token authentication. 
+        Obtain a token by calling the /v1/oauth2/token endpoint with your credentials.
+        The token is valid for one hour.
+      type: http
+      scheme: bearer
+      bearerFormat: JWT

--- a/subbot-api.yaml
+++ b/subbot-api.yaml
@@ -12,8 +12,7 @@ components:
 
   securitySchemes:
     basic_auth:
-      type: http
-      scheme: basic
+      $ref: 'shared-security.yaml#/components/securitySchemes/basic_auth'
 
   schemas:
 

--- a/subbot.yaml
+++ b/subbot.yaml
@@ -10,8 +10,7 @@ components:
 
   securitySchemes:
     basic_auth:
-      type: http
-      scheme: basic
+      $ref: 'shared-security.yaml#/components/securitySchemes/basic_auth'
 
   schemas:
 

--- a/synchronize.yaml
+++ b/synchronize.yaml
@@ -13,12 +13,9 @@ components:
 
   securitySchemes:
     basic_auth:
-      description: >
-        This is the default authentication schema for api.alcmeon.com.
-        The username is your `company_id` (the id of your environment within Alcméon).
-        The password is available from the _Applications_ configuration page within Alcméon.
-      type: http
-      scheme: basic
+      $ref: 'shared-security.yaml#/components/securitySchemes/basic_auth'
+    bearer_token:
+      $ref: 'shared-security.yaml#/components/securitySchemes/bearer_token'
 
   schemas:
     Conversation:

--- a/user.yaml
+++ b/user.yaml
@@ -14,12 +14,9 @@ components:
 
   securitySchemes:
     basic_auth:
-      description: >
-        This is the default authentication schema for api.alcmeon.com.
-        The username is your `company_id` (the id of your environment within Alcméon).
-        The password is available from the _Applications_ configuration page within Alcméon.
-      type: http
-      scheme: basic
+      $ref: 'shared-security.yaml#/components/securitySchemes/basic_auth'
+    bearer_token:
+      $ref: 'shared-security.yaml#/components/securitySchemes/bearer_token'
 
   schemas:
     Role:
@@ -79,6 +76,7 @@ components:
 
 security:
   - basic_auth: []
+  - bearer_token: []
 
 paths:
 

--- a/validate.sh
+++ b/validate.sh
@@ -1,7 +1,7 @@
 #/bin/sh
 #npm install --prefix ./ @apidevtools/swagger-cli
-for f in user subbot subbot-api inmessage exports synchronize custom-field scenarios application embed ai ai-api kakaotalk-send-api core-api auth
+for f in user subbot subbot-api inmessage exports synchronize custom-field scenarios application embed ai ai-api kakaotalk-send-api core-api oauth
 do
-  echo "Validating $f";
+  echo "- Validating $f";
   ./node_modules/@apidevtools/swagger-cli/bin/swagger-cli.js validate $f.yaml;
 done


### PR DESCRIPTION
Add bearer token auth to main endpoints, centralize security definitions in shared-security.yaml and allow anonymous OAuth token requests.